### PR TITLE
Fix to honour the Path expression given by user for ALB and ELB

### DIFF
--- a/aws-observability/apps/autoenable/auto_enable.template.yaml
+++ b/aws-observability/apps/autoenable/auto_enable.template.yaml
@@ -119,7 +119,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:956882708938:applications/sumologic-s3-logging-auto-enable
-        SemanticVersion: 1.0.3
+        SemanticVersion: 1.0.4
       Parameters:
         BucketName: !Ref ALBS3LogsBucketName
         BucketPrefix: "elasticloadbalancing"
@@ -134,7 +134,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:956882708938:applications/sumologic-s3-logging-auto-enable
-        SemanticVersion: 1.0.3
+        SemanticVersion: 1.0.4
       Parameters:
         BucketName: !Ref ELBS3LogsBucketName
         BucketPrefix: "classicloadbalancing"

--- a/aws-observability/templates/sumologic_observability.master.template.yaml
+++ b/aws-observability/templates/sumologic_observability.master.template.yaml
@@ -249,7 +249,7 @@ Parameters:
   Section5eALBS3BucketPathExpression:
     Type: String
     Description: "This is required in case the above existing bucket is already configured to receive ALB access logs. If this is blank, Sumo Logic will store logs in the path expression: *AWSLogs/*/elasticloadbalancing/*"
-    Default: "*AWSLogs/*/elasticloadbalancing/*"
+    Default: "elasticloadbalancing/AWSLogs/*/elasticloadbalancing/*"
 
   Section6aCreateCloudTrailLogSource:
     Type: String
@@ -345,7 +345,7 @@ Parameters:
   Section9eELBS3BucketPathExpression:
     Type: String
     Description: "This is required in case the above existing bucket is already configured to receive ELB access logs. If this is blank, Sumo Logic will store logs in the path expression: *AWSLogs/*/elasticloadbalancing/*"
-    Default: "*AWSLogs/*/classicloadbalancing/*"
+    Default: "classicloadbalancing/AWSLogs/*/elasticloadbalancing/*"
 
 Conditions:
   # Condition for Metrics Source
@@ -410,6 +410,10 @@ Conditions:
   auto_enable_s3_logs_elb: !And
     - !Not [!Equals [ !Ref Section9aAutoEnableS3LogsELBResourcesOptions, 'None' ]]
     - !Condition is_elb_bucket_available
+  
+  alb_bucket_path_expression_provided: !Not [!Equals [ !Ref Section5eALBS3BucketPathExpression, 'elasticloadbalancing/AWSLogs/*/elasticloadbalancing/*' ]]
+  
+  elb_bucket_path_expression_provided: !Not [!Equals [ !Ref Section9eELBS3BucketPathExpression, 'classicloadbalancing/AWSLogs/*/elasticloadbalancing/*' ]]
 
   # Condition for Auto Subscribe Lambda
   auto_subscribe_new_lambda_log_groups: !Or
@@ -472,7 +476,7 @@ Resources:
         CreateALBLogSource: !Ref Section5bALBCreateLogSource
         CreateALBS3Bucket: !If [create_alb_bucket, "Yes", "No"]
         ALBS3LogsBucketName: !Ref Section5dALBS3LogsBucketName
-        ALBS3BucketPathExpression: !If [auto_enable_s3_logs, !Sub "*AWSLogs/${AWS::AccountId}/elasticloadbalancing/${AWS::Region}/*", !Ref Section5eALBS3BucketPathExpression]
+        ALBS3BucketPathExpression: !If [alb_bucket_path_expression_provided, !Ref Section5eALBS3BucketPathExpression, !Sub "elasticloadbalancing/AWSLogs/${AWS::AccountId}/elasticloadbalancing/${AWS::Region}/*"]
         ALBLogsSourceName: !Sub "alb-logs-${AWS::Region}"
         ALBLogsSourceCategory: !FindInMap [CommonData, CollectorDetails, ALBLogsSourceCategory]
         CreateCloudTrailLogSource: !Ref Section6aCreateCloudTrailLogSource
@@ -492,7 +496,7 @@ Resources:
         CreateELBLogSource: !Ref Section9bELBCreateLogSource
         CreateELBS3Bucket: !If [create_elb_bucket, "Yes", "No"]
         ELBS3LogsBucketName: !Ref Section9dELBS3LogsBucketName
-        ELBS3BucketPathExpression: !If [auto_enable_s3_logs_elb, !Sub "*AWSLogs/${AWS::AccountId}/classicloadbalancing/${AWS::Region}/*", !Ref Section9eELBS3BucketPathExpression]
+        ELBS3BucketPathExpression: !If [elb_bucket_path_expression_provided, !Ref Section9eELBS3BucketPathExpression, !Sub "classicloadbalancing/AWSLogs/${AWS::AccountId}/elasticloadbalancing/${AWS::Region}/*"]
         ELBLogsSourceName: !Sub "elb-logs-${AWS::Region}"
         ELBLogsSourceCategory: !FindInMap [CommonData, CollectorDetails, ELBLogsSourceCategory]
 


### PR DESCRIPTION
Before this change, for both ALB and ELB is was observed that, even if the user is giving path expression in master template, that path expression is never honoured and always a hardcoded value is set. This value was generic expression of finding path for access logs in S3 bucket. Since the path created to dump access logs for ALB and ELB is the same by AWS this expression would have worked, but would have caused double ingestion if the S3 bucket for both the logs were same. 
As part of the fix, we are not checking of the user has passed any path expression. If so we will consider that expression for the path expression in the sumo created source. If user is not passing that value then we have two different expression for identifying the access path logs for alb and elb respectively to solve the double ingestion problem.